### PR TITLE
Do not generate template specializations for aliased types

### DIFF
--- a/include/orocos/kdl_msgs/typekit/Frame.h
+++ b/include/orocos/kdl_msgs/typekit/Frame.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Frame_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_Frame_TYPES_HPP
+
+#include <kdl_msgs/Frame.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::Frame >;
+    extern template class RTT::internal::DataSource< kdl_msgs::Frame >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::Frame >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::Frame >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::Frame >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::Frame >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::Frame >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::Frame >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::Frame >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::Frame >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::Frame >;
+    extern template class RTT::Constant< kdl_msgs::Frame >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/Frame.h
+++ b/include/orocos/kdl_msgs/typekit/Frame.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Frame_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_Frame_TYPES_HPP
 
 #include <kdl_msgs/Frame.h>
+
+// Skip this file if kdl_msgs::Frame is only an alias for KDL::Frame.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::Frame >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/include/orocos/kdl_msgs/typekit/JntArray.h
+++ b/include/orocos/kdl_msgs/typekit/JntArray.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_JntArray_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_JntArray_TYPES_HPP
+
+#include <kdl_msgs/JntArray.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::JntArray >;
+    extern template class RTT::internal::DataSource< kdl_msgs::JntArray >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::JntArray >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::JntArray >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::JntArray >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::JntArray >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::JntArray >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::JntArray >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::JntArray >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::JntArray >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::JntArray >;
+    extern template class RTT::Constant< kdl_msgs::JntArray >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/JntArray.h
+++ b/include/orocos/kdl_msgs/typekit/JntArray.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_JntArray_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_JntArray_TYPES_HPP
 
 #include <kdl_msgs/JntArray.h>
+
+// Skip this file if kdl_msgs::JntArray is only an alias for KDL::JntArray.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::JntArray >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/include/orocos/kdl_msgs/typekit/Rotation.h
+++ b/include/orocos/kdl_msgs/typekit/Rotation.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Rotation_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_Rotation_TYPES_HPP
+
+#include <kdl_msgs/Rotation.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::Rotation >;
+    extern template class RTT::internal::DataSource< kdl_msgs::Rotation >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::Rotation >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::Rotation >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::Rotation >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::Rotation >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::Rotation >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::Rotation >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::Rotation >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::Rotation >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::Rotation >;
+    extern template class RTT::Constant< kdl_msgs::Rotation >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/Rotation.h
+++ b/include/orocos/kdl_msgs/typekit/Rotation.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Rotation_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_Rotation_TYPES_HPP
 
 #include <kdl_msgs/Rotation.h>
+
+// Skip this file if kdl_msgs::Rotation is only an alias for KDL::Rotation.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::Rotation >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/include/orocos/kdl_msgs/typekit/Twist.h
+++ b/include/orocos/kdl_msgs/typekit/Twist.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Twist_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_Twist_TYPES_HPP
+
+#include <kdl_msgs/Twist.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::Twist >;
+    extern template class RTT::internal::DataSource< kdl_msgs::Twist >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::Twist >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::Twist >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::Twist >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::Twist >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::Twist >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::Twist >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::Twist >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::Twist >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::Twist >;
+    extern template class RTT::Constant< kdl_msgs::Twist >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/Twist.h
+++ b/include/orocos/kdl_msgs/typekit/Twist.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Twist_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_Twist_TYPES_HPP
 
 #include <kdl_msgs/Twist.h>
+
+// Skip this file if kdl_msgs::Twist is only an alias for KDL::Twist.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::Twist >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/include/orocos/kdl_msgs/typekit/Types.hpp
+++ b/include/orocos/kdl_msgs/typekit/Types.hpp
@@ -4,11 +4,17 @@
 #define __OROCOS_ROS_GENERATED_kdl_msgs_TYPES_HPP
 
 // includes Types.hpp headers for all messages:
+#include "Frame.h"
 #include "FrameStamped.h"
+#include "JntArray.h"
 #include "JntArrayStamped.h"
+#include "Rotation.h"
 #include "RotationStamped.h"
+#include "Twist.h"
 #include "TwistStamped.h"
+#include "Vector.h"
 #include "VectorStamped.h"
+#include "Wrench.h"
 #include "WrenchStamped.h"
 
 

--- a/include/orocos/kdl_msgs/typekit/Vector.h
+++ b/include/orocos/kdl_msgs/typekit/Vector.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Vector_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_Vector_TYPES_HPP
+
+#include <kdl_msgs/Vector.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::Vector >;
+    extern template class RTT::internal::DataSource< kdl_msgs::Vector >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::Vector >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::Vector >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::Vector >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::Vector >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::Vector >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::Vector >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::Vector >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::Vector >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::Vector >;
+    extern template class RTT::Constant< kdl_msgs::Vector >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/Vector.h
+++ b/include/orocos/kdl_msgs/typekit/Vector.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Vector_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_Vector_TYPES_HPP
 
 #include <kdl_msgs/Vector.h>
+
+// Skip this file if kdl_msgs::Vector is only an alias for KDL::Vector.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::Vector >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/include/orocos/kdl_msgs/typekit/Wrench.h
+++ b/include/orocos/kdl_msgs/typekit/Wrench.h
@@ -1,0 +1,36 @@
+/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
+
+#ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Wrench_TYPES_HPP
+#define __OROCOS_ROS_GENERATED_kdl_msgs_Wrench_TYPES_HPP
+
+#include <kdl_msgs/Wrench.h>
+
+// All these classes were generated in the typekit library:
+#ifdef CORELIB_DATASOURCE_HPP
+    extern template class RTT::internal::DataSourceTypeInfo< kdl_msgs::Wrench >;
+    extern template class RTT::internal::DataSource< kdl_msgs::Wrench >;
+    extern template class RTT::internal::AssignableDataSource< kdl_msgs::Wrench >;
+    extern template class RTT::internal::AssignCommand< kdl_msgs::Wrench >;
+#endif
+#ifdef ORO_CORELIB_DATASOURCES_HPP
+    extern template class RTT::internal::ValueDataSource< kdl_msgs::Wrench >;
+    extern template class RTT::internal::ConstantDataSource< kdl_msgs::Wrench >;
+    extern template class RTT::internal::ReferenceDataSource< kdl_msgs::Wrench >;
+#endif
+#ifdef ORO_OUTPUT_PORT_HPP
+    extern template class RTT::OutputPort< kdl_msgs::Wrench >;
+#endif
+#ifdef ORO_INPUT_PORT_HPP
+    extern template class RTT::InputPort< kdl_msgs::Wrench >;
+#endif
+#ifdef ORO_PROPERTY_HPP
+    extern template class RTT::Property< kdl_msgs::Wrench >;
+#endif
+#ifdef ORO_CORELIB_ATTRIBUTE_HPP
+    extern template class RTT::Attribute< kdl_msgs::Wrench >;
+    extern template class RTT::Constant< kdl_msgs::Wrench >;
+#endif
+
+
+#endif
+

--- a/include/orocos/kdl_msgs/typekit/Wrench.h
+++ b/include/orocos/kdl_msgs/typekit/Wrench.h
@@ -1,9 +1,10 @@
-/* Generated from rtt_rostopic/src/msg_Types.hpp.in */
-
 #ifndef __OROCOS_ROS_GENERATED_kdl_msgs_Wrench_TYPES_HPP
 #define __OROCOS_ROS_GENERATED_kdl_msgs_Wrench_TYPES_HPP
 
 #include <kdl_msgs/Wrench.h>
+
+// Skip this file if kdl_msgs::Wrench is only an alias for KDL::Wrench.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
@@ -31,6 +32,9 @@
     extern template class RTT::Constant< kdl_msgs::Wrench >;
 #endif
 
+#else
+#include <kdl_typekit/typekit/Types.hpp>
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 #endif
 

--- a/src/ros_Frame_typekit_plugin.cpp
+++ b/src/ros_Frame_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::Frame is only an alias for KDL::Frame.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::Frame >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::Frame >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::Frame >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::Frame >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::Frame >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;

--- a/src/ros_JntArray_typekit_plugin.cpp
+++ b/src/ros_JntArray_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::JntArray is only an alias for KDL::JntArray.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::JntArray >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::JntArray >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::JntArray >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::JntArray >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::JntArray >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;

--- a/src/ros_Rotation_typekit_plugin.cpp
+++ b/src/ros_Rotation_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::Rotation is only an alias for KDL::Rotation.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::Rotation >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::Rotation >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::Rotation >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::Rotation >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::Rotation >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;

--- a/src/ros_Twist_typekit_plugin.cpp
+++ b/src/ros_Twist_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::Twist is only an alias for KDL::Twist.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::Twist >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::Twist >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::Twist >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::Twist >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::Twist >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;

--- a/src/ros_Vector_typekit_plugin.cpp
+++ b/src/ros_Vector_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::Vector is only an alias for KDL::Vector.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::Vector >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::Vector >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::Vector >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::Vector >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::Vector >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;

--- a/src/ros_Wrench_typekit_plugin.cpp
+++ b/src/ros_Wrench_typekit_plugin.cpp
@@ -5,6 +5,9 @@
 #include <rtt/types/CArrayTypeInfo.hpp>
 #include <vector>
 
+// Skip templates if kdl_msgs::Wrench is only an alias for KDL::Wrench.
+#ifdef BOOST_NO_CXX11_TEMPLATE_ALIASES
+
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
 template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< kdl_msgs::Wrench >;
@@ -19,6 +22,8 @@ template class RTT_EXPORT RTT::InputPort< kdl_msgs::Wrench >;
 template class RTT_EXPORT RTT::Property< kdl_msgs::Wrench >;
 template class RTT_EXPORT RTT::Attribute< kdl_msgs::Wrench >;
 template class RTT_EXPORT RTT::Constant< kdl_msgs::Wrench >;
+
+#endif // BOOST_NO_CXX11_TEMPLATE_ALIASES
 
 namespace rtt_roscomm {
   using namespace RTT;


### PR DESCRIPTION
The typekit library in `rtt_kdl_msgs` contained template specializations for `kdl_msgs::Xxx` types even if they are defined as template aliases of native KDL types since https://github.com/orocos/kdl_msgs/pull/1.

With this patch these code parts are suppressed and we forward to the extern template declarations in package `kdl_typekit` instead.

This PR reverts the removal of the typekit headers in 253da4107750e8a53e074799d558c6439e174119, which was invalid for non-C++11 builds where `BOOST_NO_CXX11_TEMPLATE_ALIASES` is defined.